### PR TITLE
Fix `tar` command execution in download script

### DIFF
--- a/bin/download-imdb-crop.sh
+++ b/bin/download-imdb-crop.sh
@@ -6,6 +6,6 @@ then
 fi
 
 curl https://data.vision.ee.ethz.ch/cvl/rrothe/imdb-wiki/static/imdb_crop.tar -O
-tar -xzvf imdb_crop.tar -o data
+tar -xvf imdb_crop.tar -C data
 
 


### PR DESCRIPTION
Fix keys of `tar` inference while unpacking IMDB data set (otherwise it fails expecting `gzip`-ed input and being unable to apply `-o` option, which, as documentation reads, equals to `--no-same-owner` while extracting).